### PR TITLE
fix: respect safe-area insets in PWA mode

### DIFF
--- a/.changeset/safe-area-insets.md
+++ b/.changeset/safe-area-insets.md
@@ -1,0 +1,5 @@
+---
+"mhm-97-remake": patch
+---
+
+Pad the body with `env(safe-area-inset-*)` so iOS notch / Dynamic Island and Android cutouts no longer cover UI when installed as a PWA.

--- a/src/styles/global.css.ts
+++ b/src/styles/global.css.ts
@@ -19,7 +19,14 @@ globalStyle(":root", {
 
 globalStyle("body", {
   margin: 0,
-  padding: 0
+  // Respect iOS notch / Dynamic Island / home indicator and the equivalent
+  // cutouts on Android when installed as a PWA. `viewport-fit=cover` in the
+  // viewport meta tag is what unlocks the env() values; without these
+  // paddings content drifts under the notch in landscape.
+  paddingTop: "env(safe-area-inset-top)",
+  paddingRight: "env(safe-area-inset-right)",
+  paddingBottom: "env(safe-area-inset-bottom)",
+  paddingLeft: "env(safe-area-inset-left)"
 });
 
 globalStyle("h1", {


### PR DESCRIPTION
Pad body with env(safe-area-inset-*) so the iOS notch / Dynamic Island and Android display cutouts no longer obscure UI when the app is installed. viewport-fit=cover and apple-mobile-web-app-status-bar-style=black-translucent were already in place.
